### PR TITLE
feat: create PatientProfile model with references and fields

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,2 +1,4 @@
 class Patient < User
+  has_one :patient_profile, dependent: :destroy
+  accepts_nested_attributes_for :patient_profile
 end

--- a/app/models/patient_profile.rb
+++ b/app/models/patient_profile.rb
@@ -1,0 +1,5 @@
+class PatientProfile < ApplicationRecord
+  belongs_to :user
+
+  validates :full_name, :cpf, :phone, :birth_date, presence: true
+end

--- a/db/migrate/20250514234640_create_patient_profiles.rb
+++ b/db/migrate/20250514234640_create_patient_profiles.rb
@@ -1,0 +1,13 @@
+class CreatePatientProfiles < ActiveRecord::Migration[8.0]
+  def change
+    create_table :patient_profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :full_name
+      t.string :cpf
+      t.string :phone
+      t.date :birthday
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,64 +10,76 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_20_202248) do
-# These are extensions that must be enabled in order to support this database
-enable_extension "citext"
-enable_extension "pg_catalog.plpgsql"
+ActiveRecord::Schema[8.0].define(version: 2025_05_14_234640) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
+  enable_extension "pg_catalog.plpgsql"
 
-create_table "account_login_change_keys", force: :cascade do |t|
-  t.string "key", null: false
-  t.string "login", null: false
-  t.datetime "deadline", null: false
-end
+  create_table "account_login_change_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "login", null: false
+    t.datetime "deadline", null: false
+  end
 
-create_table "account_password_reset_keys", force: :cascade do |t|
-  t.string "key", null: false
-  t.datetime "deadline", null: false
-  t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
-end
+  create_table "account_password_reset_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "deadline", null: false
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
 
-create_table "account_remember_keys", force: :cascade do |t|
-  t.string "key", null: false
-  t.datetime "deadline", null: false
-end
+  create_table "account_remember_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "deadline", null: false
+  end
 
-create_table "account_verification_keys", force: :cascade do |t|
-  t.string "key", null: false
-  t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-  t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
-end
+  create_table "account_verification_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
+  end
 
-create_table "accounts", force: :cascade do |t|
-  t.integer "status", default: 1, null: false
-  t.citext "email", null: false
-  t.string "password_hash"
-  t.string "type", default: "User", null: false
-  t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
-  t.check_constraint "email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+.[^,@; \r\n]+$'::citext", name: "valid_email"
-end
+  create_table "accounts", force: :cascade do |t|
+    t.integer "status", default: 1, null: false
+    t.citext "email", null: false
+    t.string "password_hash"
+    t.string "type", default: "User", null: false
+    t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
+    t.check_constraint "email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+.[^,@; \r\n]+$'::citext", name: "valid_email"
+  end
 
-create_table "sessions", force: :cascade do |t|
-  t.bigint "user_id", null: false
-  t.string "ip_address"
-  t.string "user_agent"
-  t.datetime "created_at", null: false
-  t.datetime "updated_at", null: false
-  t.index ["user_id"], name: "index_sessions_on_user_id"
-end
+  create_table "patient_profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "full_name"
+    t.string "cpf"
+    t.string "phone"
+    t.date "birthday"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_patient_profiles_on_user_id"
+  end
 
-create_table "users", force: :cascade do |t|
-  t.string "email_address", null: false
-  t.string "password_digest", null: false
-  t.datetime "created_at", null: false
-  t.datetime "updated_at", null: false
-  t.string "type", default: "Admin", null: false
-  t.index ["email_address"], name: "index_users_on_email_address", unique: true
-end
+  create_table "sessions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "ip_address"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
 
-add_foreign_key "account_login_change_keys", "accounts", column: "id"
-add_foreign_key "account_password_reset_keys", "accounts", column: "id"
-add_foreign_key "account_remember_keys", "accounts", column: "id"
-add_foreign_key "account_verification_keys", "accounts", column: "id"
-add_foreign_key "sessions", "users"
+  create_table "users", force: :cascade do |t|
+    t.string "email_address", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "type", default: "Admin", null: false
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+  end
+
+  add_foreign_key "account_login_change_keys", "accounts", column: "id"
+  add_foreign_key "account_password_reset_keys", "accounts", column: "id"
+  add_foreign_key "account_remember_keys", "accounts", column: "id"
+  add_foreign_key "account_verification_keys", "accounts", column: "id"
+  add_foreign_key "patient_profiles", "users"
+  add_foreign_key "sessions", "users"
 end

--- a/spec/factories/patient_profiles.rb
+++ b/spec/factories/patient_profiles.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :patient_profile do
+    user { nil }
+    full_name { "MyString" }
+    cpf { "MyString" }
+    phone { "MyString" }
+    birthday { "2025-05-14" }
+  end
+end

--- a/spec/models/patient_profile_spec.rb
+++ b/spec/models/patient_profile_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PatientProfile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## What was done

This PR introduces the `PatientProfile` model to store personal data related to patients. It is associated with the `Patient` model, which is a subclass of `User` using Single Table Inheritance (STI).

## Main changes

- Added `PatientProfile` model with the following fields:
  - `user:references` (foreign key to `Patient`)
  - `full_name:string`
  - `cpf:string`
  - `phone:string`
  - `birth_date:date`
- Generated corresponding database migration
- Added the following to the `Patient` model:
  - `has_one :patient_profile, dependent: :destroy`
  - `accepts_nested_attributes_for :patient_profile`

## Next steps

- Implement CRUD for `PatientProfile` in `PatientProfilesController`
- Create Tailwind-based views for create/edit/show/index
- Restrict access to secretaries using `before_action :require_secretary`

---

🩺 This is part of **Phase 1 of ClinicSync's MVP**, focused on patient management features.
