### PR TITLE
feat: implement PatientProfilesController with full CRUD actions

### DIFF
--- a/app/controllers/patient_profiles_controller.rb
+++ b/app/controllers/patient_profiles_controller.rb
@@ -1,0 +1,64 @@
+class PatientProfilesController < ApplicationController
+  before_action :require_secretary
+  before_action :set_patient_profile, only: %i[show edit update destroy]
+
+  def index
+    @patient_profiles = PatientProfile.includes(:user)
+  end
+
+  def show
+  end
+
+  def new
+    @patient = Patient.new
+    @patient.build_patient_profile
+  end
+
+  def create
+    @patient = Patient.new(patient_params)
+    if @patient.save
+      redirect_to patient_profile_path(@patient.patient_profile), notice: "Patient created successfully."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @patient = @patient_profile.user
+  end
+
+  def update
+    @patient = @patient_profile.user
+    if @patient.update(patient_params)
+      redirect_to patient_profile_path(@patient_profile), notice: "Patient updated successfully."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @patient_profile.user.destroy
+    redirect_to patient_profiles_path, notice: "Patient deleted successfully."
+  end
+
+  private
+
+  def set_patient_profile
+    @patient_profile = PatientProfile.find(params[:id])
+  end
+
+  def patient_params
+    params.require(:patient).permit(
+      :email_address,
+      :password,
+      :password_confirmation,
+      patient_profile_attributes: %i[full_name cpf phone birth_date]
+    )
+  end
+
+  def require_secretary
+  unless user_signed_in? && AuthorizeUser.call(current_user, Secretary)
+      redirect_to root_path, alert: "You are not authorized to access this page."
+  end
+  end
+end

--- a/app/helpers/patient_profiles_helper.rb
+++ b/app/helpers/patient_profiles_helper.rb
@@ -1,0 +1,2 @@
+module PatientProfilesHelper
+end

--- a/app/views/patient_profiles/create.html.erb
+++ b/app/views/patient_profiles/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#create</h1>
+  <p>Find me in app/views/patient_profiles/create.html.erb</p>
+</div>

--- a/app/views/patient_profiles/destroy.html.erb
+++ b/app/views/patient_profiles/destroy.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#destroy</h1>
+  <p>Find me in app/views/patient_profiles/destroy.html.erb</p>
+</div>

--- a/app/views/patient_profiles/edit.html.erb
+++ b/app/views/patient_profiles/edit.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#edit</h1>
+  <p>Find me in app/views/patient_profiles/edit.html.erb</p>
+</div>

--- a/app/views/patient_profiles/index.html.erb
+++ b/app/views/patient_profiles/index.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#index</h1>
+  <p>Find me in app/views/patient_profiles/index.html.erb</p>
+</div>

--- a/app/views/patient_profiles/new.html.erb
+++ b/app/views/patient_profiles/new.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#new</h1>
+  <p>Find me in app/views/patient_profiles/new.html.erb</p>
+</div>

--- a/app/views/patient_profiles/show.html.erb
+++ b/app/views/patient_profiles/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#show</h1>
+  <p>Find me in app/views/patient_profiles/show.html.erb</p>
+</div>

--- a/app/views/patient_profiles/update.html.erb
+++ b/app/views/patient_profiles/update.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">PatientProfiles#update</h1>
+  <p>Find me in app/views/patient_profiles/update.html.erb</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :patient_profiles
   get "/admin/home", to: "admins#home", as: "admins_home"
   get "/doctors/home", to: "doctors#home", as: "doctors_home"
   get "/secretaries/home", to: "secretaries#home", as: "secretaries_home"

--- a/spec/helpers/patient_profiles_helper_spec.rb
+++ b/spec/helpers/patient_profiles_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PatientProfilesHelper. For example:
+#
+# describe PatientProfilesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PatientProfilesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/patient_profile_spec.rb
+++ b/spec/models/patient_profile_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+girequire 'rails_helper'
 
 RSpec.describe PatientProfile, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"

--- a/spec/views/patient_profiles/create.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/create.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/create.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/patient_profiles/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/destroy.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/destroy.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/patient_profiles/edit.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/edit.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/edit.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/patient_profiles/index.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/index.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/index.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/patient_profiles/new.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/new.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/new.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/patient_profiles/show.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/show.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/show.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/patient_profiles/update.html.tailwindcss_spec.rb
+++ b/spec/views/patient_profiles/update.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "patient_profiles/update.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## What was done

This PR adds the full controller logic for managing patient profiles. Only users with the `Secretary` role are authorized to access these actions.

## Main changes

- Created `PatientProfilesController` with actions:
  - `index`, `show`, `new`, `create`, `edit`, `update`, `destroy`
- Implemented patient creation using nested attributes (`PatientProfile` inside `Patient`)
- Restricted controller access using `before_action :require_secretary`
- Removed auto-generated request spec (`patient_profiles_spec.rb`) as it does not reflect actual behavior

## Next steps

- Create Tailwind-based views for patient creation and editing
- Add system tests with Capybara (after view layer is ready)
- Style the patient index and show pages for secretary dashboard

---

📁 This completes the controller logic for patient management in **Phase 1 of ClinicSync's MVP**.
