### PR TITLE
refactor: migrate from Rodauth to native Rails authentication

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -6,7 +6,7 @@ class PasswordsController < ApplicationController
   end
 
   def create
-    if user = User.find_by(email_address: params[:email_address])
+    if user = User.find_by(email: params[:email])
       PasswordsMailer.reset(user).deliver_later
     end
 

--- a/app/controllers/patient_profiles_controller.rb
+++ b/app/controllers/patient_profiles_controller.rb
@@ -49,7 +49,7 @@ class PatientProfilesController < ApplicationController
 
   def patient_params
     params.require(:patient).permit(
-      :email_address,
+      :email,
       :password,
       :password_confirmation,
       patient_profile_attributes: %i[full_name cpf phone birth_date]

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@ class SessionsController < ApplicationController
   rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
 
   def create
-  user = AuthenticateUser.call(params[:email_address], params[:password])
+  user = AuthenticateUser.call(params[:email], params[:password])
 
   if user
     start_new_session_for user

--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -1,6 +1,6 @@
 class PasswordsMailer < ApplicationMailer
   def reset(user)
     @user = user
-    mail subject: "Reset your password", to: user.email_address
+    mail subject: "Reset your password", to: user.email
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,5 @@ class User < ApplicationRecord
   has_secure_password
   has_many :sessions, dependent: :destroy
 
-  normalizes :email_address, with: ->(e) { e.strip.downcase }
+  normalizes :email, with: ->(e) { e.strip.downcase }
 end

--- a/app/services/authenticate_user.rb
+++ b/app/services/authenticate_user.rb
@@ -1,5 +1,5 @@
 class AuthenticateUser
-  def self.call(email_address, password)
-    User.authenticate_by(email_address: email_address, password: password)
+  def self.call(email, password)
+    User.authenticate_by(email: email, password: password)
   end
 end

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -7,7 +7,7 @@
 
   <%= form_with url: passwords_path, class: "contents" do |form| %>
     <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.email_field :email, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="inline">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -11,7 +11,7 @@
 
   <%= form_with url: session_path, method: :post, data: { turbo: false } do |form| %>
     <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.email_field :email, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email", value: params[:email], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">

--- a/db/migrate/20250515234658_remove_rodauth_legacy.rb
+++ b/db/migrate/20250515234658_remove_rodauth_legacy.rb
@@ -1,0 +1,12 @@
+class RemoveRodauthLegacy < ActiveRecord::Migration[8.0]
+  def change
+    drop_table :account_login_change_keys, if_exists: true
+    drop_table :account_password_reset_keys, if_exists: true
+    drop_table :account_remember_keys, if_exists: true
+    drop_table :account_verification_keys, if_exists: true
+    drop_table :accounts, if_exists: true
+
+    remove_foreign_key :patient_profiles, :users, if_exists: true
+    remove_foreign_key :sessions, :users, if_exists: true
+  end
+end

--- a/db/migrate/20250515234706_fix_email_standardization.rb
+++ b/db/migrate/20250515234706_fix_email_standardization.rb
@@ -1,0 +1,9 @@
+class FixEmailStandardization < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :users, :email_address, :email
+
+    change_column :users, :email, :citext
+
+    add_index :users, :email, unique: true, name: 'index_users_on_unique_email'
+  end
+end

--- a/db/migrate/20250515235850_rename_account_id_back_to_user_id.rb
+++ b/db/migrate/20250515235850_rename_account_id_back_to_user_id.rb
@@ -1,0 +1,6 @@
+class RenameAccountIdBackToUserId < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :patient_profiles, :account_id, :user_id
+    rename_column :sessions, :account_id, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,42 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_14_234640) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_15_235850) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
-
-  create_table "account_login_change_keys", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "login", null: false
-    t.datetime "deadline", null: false
-  end
-
-  create_table "account_password_reset_keys", force: :cascade do |t|
-    t.string "key", null: false
-    t.datetime "deadline", null: false
-    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
-  end
-
-  create_table "account_remember_keys", force: :cascade do |t|
-    t.string "key", null: false
-    t.datetime "deadline", null: false
-  end
-
-  create_table "account_verification_keys", force: :cascade do |t|
-    t.string "key", null: false
-    t.datetime "requested_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
-    t.datetime "email_last_sent", default: -> { "CURRENT_TIMESTAMP" }, null: false
-  end
-
-  create_table "accounts", force: :cascade do |t|
-    t.integer "status", default: 1, null: false
-    t.citext "email", null: false
-    t.string "password_hash"
-    t.string "type", default: "User", null: false
-    t.index ["email"], name: "index_accounts_on_email", unique: true, where: "(status = ANY (ARRAY[1, 2]))"
-    t.check_constraint "email ~ '^[^,;@ \r\n]+@[^,@; \r\n]+.[^,@; \r\n]+$'::citext", name: "valid_email"
-  end
 
   create_table "patient_profiles", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -68,18 +36,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_14_234640) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email_address", null: false
+    t.citext "email", null: false
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type", default: "Admin", null: false
-    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email"], name: "index_users_on_unique_email", unique: true
   end
-
-  add_foreign_key "account_login_change_keys", "accounts", column: "id"
-  add_foreign_key "account_password_reset_keys", "accounts", column: "id"
-  add_foreign_key "account_remember_keys", "accounts", column: "id"
-  add_foreign_key "account_verification_keys", "accounts", column: "id"
-  add_foreign_key "patient_profiles", "users"
-  add_foreign_key "sessions", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,23 +1,23 @@
 Admin.create!(
-  email_address: 'admin@admin.com',
+  email: 'admin@admin.com',
   password: 'admin',
   password_confirmation: 'admin'
 )
 
 Doctor.create!(
-  email_address: 'doctor@doctor.com',
+  email: 'doctor@doctor.com',
   password: 'doctor',
   password_confirmation: 'doctor'
 )
 
 Secretary.create!(
-  email_address: 'secretary@secretary.com',
+  email: 'secretary@secretary.com',
   password: 'secretary',
   password_confirmation: 'secretary'
 )
 
 Patient.create!(
-  email_address: 'patient@patient.com',
+  email: 'patient@patient.com',
   password: 'patient',
   password_confirmation: 'patient'
 )

--- a/spec/models/patient_profile_spec.rb
+++ b/spec/models/patient_profile_spec.rb
@@ -1,4 +1,4 @@
-girequire 'rails_helper'
+require 'rails_helper'
 
 RSpec.describe PatientProfile, type: :model do
   pending "add some examples to (or delete) #{__FILE__}"


### PR DESCRIPTION
## Summary

This PR removes all Rodauth legacy schema and migrates the application to use native Rails authentication via `has_secure_password`.

## Key changes

- Dropped Rodauth-related tables: `accounts`, `account_login_change_keys`, etc.
- Renamed `email_address` to `email` with `citext` type and unique index
- Updated all models, services, controllers, mailers, and views to use `email`
- Corrected `PatientProfilesController`, `SessionsController`, `PasswordsController`
- Recreated `db/seeds.rb` using `email` and valid password digests
- Verified login functionality manually

## Migration notice

Run the following to ensure consistency after pulling this branch:
```bash
rails db:reset
